### PR TITLE
Replace deprecated wandb function with working alternative.

### DIFF
--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -15,10 +15,10 @@ logger = logging.getLogger(__name__)
 
 def get_wandb_printer() -> Literal["Printer"]:
     """Returns a wandb printer instance for pretty stdout."""
-    from wandb.sdk.lib.printer import get_printer
+    from wandb.sdk.lib.printer import new_printer
     from wandb.sdk.wandb_settings import Settings
 
-    printer = get_printer(Settings()._jupyter)
+    printer = new_printer(Settings()._jupyter)
     return printer
 
 


### PR DESCRIPTION
Fix a bug which was showing up because there was a legacy wandb function being used in the codebase. 
bug: 
```
  File "/Users/kish/Downloads/codestuff/MILU/lm_eval/loggers/wandb_logger.py", line 18, in get_wandb_printer
    from wandb.sdk.lib.printer import get_printer
ImportError: cannot import name 'get_printer' from 'wandb.sdk.lib.printer' (/Users/kish/Downloads/codestuff/lang/lib/python3.12/site-packages/wandb/sdk/lib/printer.py)
```

there was a one line fix for this: 
replaced  
`from wandb.sdk.lib.printer import get_printer`
with  
`from wandb.sdk.lib.printer import new_printer`